### PR TITLE
Search cdm updates

### DIFF
--- a/_includes/all-collections-nav-json.html
+++ b/_includes/all-collections-nav-json.html
@@ -2,9 +2,18 @@
 <div class="modal fade" id="collections" tabindex="-1" role="dialog" aria-labelledby="digital" aria-hidden="true">
     <div class="modal-dialog" role="document">
         <div class="modal-content">
-            <div class="modal-header">
-                <h5 class="modal-title" id="digital"><a href="https://www.lib.uidaho.edu/digital/">UIdaho Library Digital Initiatives</a></h5>
-                <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+            <div class="modal-header bg-dark">
+                <div class="row align-items-center text-center">
+                    <div class="col-5">
+                        <a href="https://www.lib.uidaho.edu/"><img class="img-fluid" alt="University of Idaho Library home" src="https://www.lib.uidaho.edu/media/digital/liblogo_transparent.png" ></a>
+                    </div>
+                    <div class="col-6">
+                        <a href="https://www.lib.uidaho.edu/digital/" target="_blank" rel="noopener">
+                            <img class="img-fluid" src="https://www.lib.uidaho.edu/media/digital/bannerlogo_allwhite.png" alt="{{ site.organization-name }}Digital Initiatives, University of Idaho Library home" >
+                        </a>
+                    </div>
+                </div>
+                <button type="button" class="close text-white" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
             </div>
             <div class="modal-body">
                 <div class="row align-items-center mb-3">
@@ -18,7 +27,7 @@
                                 window.open("https://digital.lib.uidaho.edu/digital/search/searchterm/" + encodeURIComponent(query) + "/field/all/mode/all/conn/and/order/nosort/ad/asc", "_blank" );
                             }
                         </script>
-                        <form class="form-inline" role="search" id="search" onsubmit="cdm_search_all(); return false;">
+                        <form class="form-inline" role="search" id="all-collections-search" onsubmit="cdm_search_all(); return false;">
                         <div class="input-group">
                             <input id="cdm-search-all" type="text" class="form-control" placeholder="Search all collections..." aria-label="Search all collections" aria-describedby="search-all-button">
                             <div class="input-group-append">

--- a/_includes/banner.html
+++ b/_includes/banner.html
@@ -39,8 +39,8 @@
                             {% endif %}
                             {%- endfor -%}
                             <br>
-                        <button type="button" class="btn btn-info mt-4 mx-2 px-3" data-backdrop="false" id="mobile-nav-image" data-toggle="modal" data-target="#collections">Browse All Collections</button>
-                        <button type="button" class="btn btn-pride-gold mt-4 mx-2 px-3" data-backdrop="false" id="search-collections-modal-button" data-toggle="modal" data-target="#search-coll-mod">Search Across All Collections</button>
+                        <button type="button" class="btn btn-info mt-4 mx-2 px-3" id="mobile-nav-image" data-toggle="modal" data-target="#collections">Browse All Collections</button>
+                        <button type="button" class="btn btn-pride-gold mt-4 mx-2 px-3" id="search-collections-modal-button" data-toggle="modal" data-target="#search-coll-mod">Search Across All Collections</button>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
@owikle this:
- updates cdm all collections nav to match cb-cdm-template (header update)
- removes the `data-backdrop="false"` option from the modal buttons on index (i am not sure if this was added at some point to fix some other issue? however, I feel like having backdrop false makes it a bit harder to use, since you can't just click away. it seems to work fine as far as I can tell. looks better with updated all collections nav)